### PR TITLE
Use Java 8 in automated Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-jdk: oraclejdk7
+jdk: oraclejdk8
 
 branches:
   only:


### PR DESCRIPTION
Java 7 is missing:

```bash
$ jdk_switcher use oraclejdk7
Switching to Oracle JDK7 (java-7-oracle), JAVA_HOME will be set to /usr/lib/jvm/java-7-oracle
update-java-alternatives: directory does not exist: /usr/lib/jvm/java-7-oracle
$ java -Xmx32m -version
java version "1.8.0_151"
Java(TM) SE Runtime Environment (build 1.8.0_151-b12)
Java HotSpot(TM) 64-Bit Server VM (build 25.151-b12, mixed mode)
$ javac -J-Xmx32m -version
javac 1.8.0_151
```