### PR TITLE
fixed boolean getters recognition, improved performance

### DIFF
--- a/core/src/test/java/org/javasimon/utils/bean/ClassUtilsTest.java
+++ b/core/src/test/java/org/javasimon/utils/bean/ClassUtilsTest.java
@@ -10,12 +10,14 @@ import java.util.Set;
 
 /**
  * @author <a href="mailto:ivan.mushketyk@gmail.com">Ivan Mushketyk</a>
+ * @author <a href="mailto:anton.rybochkin@axibase.com">Anton Rybochkin</a>
  */
 public class ClassUtilsTest extends SimonUnitTest {
 
 	private static class TestBean {
 		int intField;
 		String strField;
+		boolean boolField;
 
 		public int getIntField() {
 			return intField;
@@ -35,6 +37,14 @@ public class ClassUtilsTest extends SimonUnitTest {
 
 		public void setStrField(TestBean bean) {
 
+		}
+
+		public boolean isBoolField() {
+			return boolField;
+		}
+
+		public void setBoolField(boolean boolField) {
+			this.boolField = boolField;
 		}
 
 		public void otherMethod(String str, int i) {
@@ -134,6 +144,12 @@ public class ClassUtilsTest extends SimonUnitTest {
 	public void getGetter() throws Exception {
 		Method getter = ClassUtils.getGetter(TestBean.class, "intField");
 		Assert.assertEquals(getter, TestBean.class.getDeclaredMethod("getIntField"));
+	}
+
+	@Test
+	public void getBooleanGetter() throws Exception {
+		Method getter = ClassUtils.getGetter(TestBean.class, "boolField");
+		Assert.assertEquals(getter, TestBean.class.getDeclaredMethod("isBoolField"));
 	}
 
 	@Test


### PR DESCRIPTION
By convention, accessors to boolean fields are generated with `is` prefix. If getter with `get` method is not found, try to find one with `is` prefix.

Some performance fix was made with assumption that most getters and setters have public visibility. In this case it is faster to call `Class.getMethod` method which searches for method defined in parent classes and works about 30 per cent faster (see the [benchmark](https://github.com/raipc/benchmarks/blob/master/src/main/java/com/github/raipc/ReflectionBenchmark.java)).
If number of methods defined in target class is small, it may be faster to call `Class.getDeclaredMethods()` and check method name and arguments (but I didn't implement this algorithm)