### PR TITLE
Fix bug init oldNanos in class Calibration

### DIFF
--- a/core/src/main/java/org/javasimon/clock/SimonClockUtils.java
+++ b/core/src/main/java/org/javasimon/clock/SimonClockUtils.java
@@ -63,6 +63,7 @@ public class SimonClockUtils {
 
 		static {
 			initMillis = System.currentTimeMillis();
+			initNanos = System.nanoTime();
 			long oldNanos;
 			while (true) {
 				oldNanos = System.nanoTime();


### PR DESCRIPTION
The error occurred when nextMillis> initMillis was in the first iteration. Since initNanos has not been initialized, the method
**_public static long millisForNano (long nanos)_** 
returns the wrong time.

Sorry for my English not good